### PR TITLE
docs(useQuery): remove suspense option in useQuery() v5

### DIFF
--- a/docs/react/reference/useQuery.md
+++ b/docs/react/reference/useQuery.md
@@ -51,7 +51,6 @@ const {
   select,
   staleTime,
   structuralSharing,
-  suspense,
   throwOnError,
 })
 ```
@@ -136,11 +135,6 @@ const {
 - `select: (data: TData) => unknown`
   - Optional
   - This option can be used to transform or select a part of the data returned by the query function. It affects the returned `data` value, but does not affect what gets stored in the query cache.
-- `suspense: boolean`
-  - Optional
-  - Set this to `true` to enable suspense mode.
-  - When `true`, `useQuery` will suspend when `status === 'pending'`
-  - When `true`, `useQuery` will throw runtime errors when `status === 'error'`
 - `initialData: TData | () => TData`
   - Optional
   - If set, this value will be used as the initial data for the query cache (as long as the query hasn't been created or cached yet)


### PR DESCRIPTION
In v5, To use `suspense` developers can use `useSuspenseQuery()` and can't use `useQuery()`.

However, according to the documentation, it is different.

In the actual type definition, `suspense` option is Omited, so the documentation is incorrect. So I fixed it
